### PR TITLE
modify jvm-opts for better benchmarking

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,6 @@
                  [prismatic/schema "1.0.4"]]
   :plugins [[io.aviso/pretty "0.1.23"]]
   :main ^:skip-aot validation-benchmark.core
-  :jvm-opts []
+  :jvm-opts ^:replace ["-server" "-XX:+AggressiveOpts"]
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})


### PR DESCRIPTION
- adds the ^:replace flag so that Leiningen's default jvm-opts settings are not used (they are optimized for startup not JIT compilation)
- sets -server explicitly (although it will probably get set implicitly for most places this is run)
- sets -XX:+AggressiveOpts which I find is generally a good idea for benchmark testing - AggressiveOpts enables optimizations that are expected to become the default in the next version of the JVM. 

I would recommend using the latest JDK 8 version while running the test as well and including the version you're using in the benchmark output - it's in the System properties as java.version or java.runtime.version, can't remember which.
