### PR TITLE
pre-def specs used in spec testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+.idea/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Run the benchmark with the command below, note that this will take a long time:
 
     $ lein run
 
+Or the quick(er) test with:
+
+    $ lein run -- --mode quick
+
+You can also modify the file at  resources/tests.edn to affect which libs and tests get run.
 
 To display command line help:
 

--- a/project.clj
+++ b/project.clj
@@ -11,11 +11,11 @@
                  [incanter/incanter-core "1.5.6"]
                  [incanter/incanter-charts "1.5.6"]
                  [io.aviso/pretty "0.1.23"]
-                 [org.clojure/clojure "1.9.0-alpha4"]
+                 [org.clojure/clojure "1.9.0-alpha5"]
                  [org.clojure/tools.cli "0.3.3"]
                  [prismatic/schema "1.0.4"]]
   :plugins [[io.aviso/pretty "0.1.23"]]
   :main ^:skip-aot validation-benchmark.core
-  :jvm-opts []
+  :jvm-opts ^:replace ["-server" "-XX:+AggressiveOpts"]
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/src/validation_benchmark/lib/spec.clj
+++ b/src/validation_benchmark/lib/spec.clj
@@ -7,7 +7,6 @@
 (s/def ::name string?)
 (s/def ::saiyan? (s/or :t true? :f false?))
 (s/def ::age integer?)
-(s/def ::Person? #(instance? Person %))
 
 
 (defn atomic-keyword [v]
@@ -18,25 +17,31 @@
   (s/conform number? v))
 
 
+(s/def ::nilable-saiyan? (s/nilable (s/or :t true? :f false?)))
 (defn nil-allowed-bool [v]
-  (s/conform (s/nilable (s/or :t true? :f false?)) v))
+  (s/conform ::nilable-saiyan? v))
 
 
+(s/def ::nilable-number (s/nilable number?))
 (defn nil-allowed-number [v]
-  (s/conform (s/nilable number?) v))
+  (s/conform ::nilable-number v))
 
 
+(s/def ::nilable-string (s/nilable string?))
 (defn nil-allowed-string [v]
-  (s/conform (s/nilable string?) v))
+  (s/conform ::nilable-string v))
 
 
+(s/def ::person (s/keys :req-un [::name ::saiyan? ::age]))
 (defn person-map [v]
-  (s/conform (s/keys :req-un [::name ::saiyan? ::age]) v))
+  (s/conform ::person v))
 
 
+(s/def ::Person? #(instance? Person %))
+(s/def ::typed-person (s/and ::Person?
+                        (s/keys :req-un [::name ::saiyan? ::age])))
 (defn person-record [v]
-  (s/conform (s/and ::Person?
-                    (s/keys :req-un [::name ::saiyan? ::age]))
+  (s/conform ::typed-person
              v))
 
 
@@ -44,37 +49,40 @@
   (s/conform prime? v))
 
 
+(s/def ::range (s/tuple (partial in-range? 0.0 1.0)
+                 (partial in-range? 1 10)
+                 (partial in-range? 1 100)))
 (defn range-check [v]
-  (s/conform (s/tuple (partial in-range? 0.0 1.0)
-                      (partial in-range? 1 10)
-                      (partial in-range? 1 100))
-             v))
+  (s/conform ::range v))
 
 
+(s/def ::keyword-set (s/and set?
+                       (s/coll-of keyword? #{})))
 (defn set-of-keywords [v]
-  (s/conform (s/and set?
-                    (s/coll-of keyword? #{})) v))
+  (s/conform ::keyword-set v))
 
+
+(s/def ::three-tuple
+  (s/and coll?
+    #(= (count %) 3)
+    #(keyword? (first %))
+    #(string? (second %))
+    #(number? (nth % 2))))
 
 (defn three-tuple [v]
   ;; (s/conform (s/tuple keyword? string? number?) v)
-  (s/conform (s/and coll?
-                    #(= (count %) 3)
-                    #(keyword? (first %))
-                    #(string? (second %))
-                    #(number? (nth % 2)))
-             v))
+  (s/conform ::three-tuple v))
 
+
+(s/def ::vector-of-two-elements (s/and (s/coll-of nil [])
+                                  (s/tuple nil nil)))
 
 (defn vector-of-two-elements [v]
-  (s/conform (s/and (s/coll-of nil [])
-                    (s/tuple nil nil))
-             v))
+  (s/conform ::vector-of-two-elements v))
 
 
 (defn vector-of-variable-length [v]
   (s/conform vector? v))
-
 
 (defn wrapper [f valid?]
   (fn [v]


### PR DESCRIPTION
We expect specs to be pre-registered in almost all use cases and (particularly in some of the later tests here) there is a significant amount of work being re-done in the hot loop. Pre-def'ing yields better performance.
