### PR TITLE
Run in awt headless mode

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,6 @@
                  [prismatic/schema "1.0.4"]]
   :plugins [[io.aviso/pretty "0.1.23"]]
   :main ^:skip-aot validation-benchmark.core
-  :jvm-opts ^:replace ["-server" "-XX:+AggressiveOpts"]
+  :jvm-opts ^:replace ["-server" "-XX:+AggressiveOpts" "-Djava.awt.headless=true"]
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})


### PR DESCRIPTION
Prevents losing focus in your terminal when loading the charting lib.
