### PR TITLE
switch to alpha12 and make the spec tests cleaner

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [incanter/incanter-core "1.5.6"]
                  [incanter/incanter-charts "1.5.6"]
                  [io.aviso/pretty "0.1.26"]
-                 [org.clojure/clojure "1.9.0-alpha11"]
+                 [org.clojure/clojure "1.9.0-alpha12"]
                  [org.clojure/tools.cli "0.3.5"]
                  [prismatic/schema "1.1.3"]]
   :plugins [[io.aviso/pretty "0.1.26"]]

--- a/src/validation_benchmark/lib/spec.clj
+++ b/src/validation_benchmark/lib/spec.clj
@@ -6,9 +6,9 @@
 
 (s/def ::age int?)
 (s/def ::name string?)
-(s/def ::keyword-set (s/and set?
-                            (s/coll-of keyword?)))
-(s/def ::nilable-saiyan? (s/nilable (s/or :t true? :f false?)))
+(s/def ::saiyan? (s/or :t true? :f false?))
+(s/def ::keyword-set (s/every keyword :kind set?))
+(s/def ::nilable-saiyan? (s/nilable ::saiyan?))
 (s/def ::nilable-number (s/nilable number?))
 (s/def ::nilable-string (s/nilable string?))
 (s/def ::person (s/keys :req-un [::name ::saiyan? ::age]))
@@ -16,70 +16,29 @@
 (s/def ::range (s/tuple (partial in-range? 0.0 1.0)
                         (partial in-range? 1 10)
                         (partial in-range? 1 100)))
-(s/def ::saiyan? (s/or :t true? :f false?))
 (s/def ::three-tuple
-  (s/and coll?
-         #(= (count %) 3)
-         #(keyword? (first %))
-         #(string? (second %))
-         #(number? (nth % 2))))
+  (s/and coll? (s/conformer vec) (s/tuple keyword? string? number?)))
 (s/def ::typed-person (s/and ::Person?
                              (s/keys :req-un [::name ::saiyan? ::age])))
 (s/def ::vector-of-two-elements (s/and vector? #(= 2 (count %))))
 
+(defn checker [s]
+  (let [spec (s/spec s)]
+    #(s/valid? spec %)))
 
-(defn atomic-keyword [v]
-  (s/valid? keyword?  v))
-
-
-(defn atomic-number [v]
-  (s/valid? number? v))
-
-
-(defn nil-allowed-bool [v]
-  (s/valid? ::nilable-saiyan? v))
-
-
-(defn nil-allowed-number [v]
-  (s/valid? ::nilable-number v))
-
-
-(defn nil-allowed-string [v]
-  (s/valid? ::nilable-string v))
-
-
-(defn person-map [v]
-  (s/valid? ::person v))
-
-
-(defn person-record [v]
-  (s/valid? ::typed-person
-             v))
-
-
-(defn primes [v]
-  (s/valid? prime? v))
-
-
-(defn range-check [v]
-  (s/valid? ::range v))
-
-
-(defn set-of-keywords [v]
-  (s/valid? ::keyword-set v))
-
-
-
-(defn three-tuple [v]
-  (s/valid? ::three-tuple v))
-
-
-(defn vector-of-two-elements [v]
-  (s/valid? ::vector-of-two-elements v))
-
-
-(defn vector-of-variable-length [v]
-  (s/valid? vector? v))
+(def atomic-keyword (checker keyword?))
+(def atomic-number (checker number?))
+(def nil-allowed-bool (checker ::nilable-saiyan?))
+(def nil-allowed-number (checker ::nilable-number))
+(def nil-allowed-string (checker ::nilable-string))
+(def person-map (checker ::person))
+(def person-record (checker ::typed-person))
+(def primes (checker prime?))
+(def range-check (checker ::range))
+(def set-of-keywords (checker ::keyword-set))
+(def three-tuple (checker ::three-tuple))
+(def vector-of-two-elements (checker ::vector-of-two-elements))
+(def vector-of-variable-length (checker vector?))
 
 (defn wrapper [f valid?]
   (fn [v]


### PR DESCRIPTION
Clojure 1.9.0-alpha12 contains substantial performance enhancements and it would be nice to get a new run of the benchmark. Thanks!
