### PR TITLE
faster spec boolean validation

### DIFF
--- a/src/validation_benchmark/lib/spec.clj
+++ b/src/validation_benchmark/lib/spec.clj
@@ -6,7 +6,7 @@
 
 (s/def ::age int?)
 (s/def ::name string?)
-(s/def ::saiyan? (s/or :t true? :f false?))
+(s/def ::saiyan? boolean?)
 (s/def ::keyword-set (s/every keyword :kind set?))
 (s/def ::nilable-saiyan? (s/nilable ::saiyan?))
 (s/def ::nilable-number (s/nilable number?))


### PR DESCRIPTION
I tried the existing solution against `#{true false}` and a simple `boolean?`, the latter seems to win (seems 30% faster on my machine in a quick and dirty bench). 
Maybe @puredanger can shed some light on why `s/or` is used instead, there might be a good reason that escaped me.
